### PR TITLE
Improved date parsing logic for remind command

### DIFF
--- a/DiscordBotNew/DiscordBot.cs
+++ b/DiscordBotNew/DiscordBot.cs
@@ -58,7 +58,7 @@ namespace DiscordBotNew
             Countdowns = new SettingsManager(SettingsManager.BasePath + "countdowns.json");
             remindersManager = new SettingsManager(SettingsManager.BasePath + "reminders.json");
             StatusSettings.GetSetting("statuses", out Dictionary<ulong, UserStatusInfo> statuses);
-            CurrentUserStatuses = statuses;
+            CurrentUserStatuses = statuses ?? new Dictionary<ulong, UserStatusInfo>();
             Client = new DiscordSocketClient();
             RestClient = new DiscordRestClient();
             Grammar = new GrammarPolice(this);


### PR DESCRIPTION
Added support for the following:
- Fancier 1d12h3m23s (1 day, 12 hours, 3 minutes, and 23 seconds) style delta times
- Raw `DateTimeOffset` parse strings (i.e. as used in !countdown, untested feature)
- Human-friendly relative times: `(tomorrow|any day of week) optionally:12hr time, minutes [0 if omitted]`

Examples of human friendly time strings:
- "Tomorrow": this will parse as the next day, Pacific Time, 8AM
- "Tomorrow 9:30 PM": this will parse as the next day, Pacific Time, 9:30 PM
- "Wednesday 12 AM": this will parse as midnight of the following Wednesday, Pacific Time. If the current day is Wednesday, 7 days from today will be used.
- "Saturday": this will parse as 8AM of the following Saturday, Pacific Time

Also added a minor bugfix, initialize user status dictionary if it hadn't already been. This is in its own commit and consequently should be easy to isolate if desired.